### PR TITLE
Export git-domain/repo-directory-name

### DIFF
--- a/main/src/dda/pallet/dda_git_crate/domain.clj
+++ b/main/src/dda/pallet/dda_git_crate/domain.clj
@@ -51,6 +51,8 @@
        {infra/facility infra/GitInfra}
        spec-domain/InfraResult))
 
+(def repo-directory-name repo/repo-directory-name)
+
 (defn-
   configuration
   [user-config]


### PR DESCRIPTION
Caused by https://github.com/DomainDrivenArchitecture/dda-smeagol-crate/commit/7283b0aed749e63e7504c6aa4cbe442d274dbcfa#diff-3fece8b6a3a8301f46178d93e85f64a1R21